### PR TITLE
Add switch/case keywords

### DIFF
--- a/syntaxes/ahk.tmLanguage
+++ b/syntaxes/ahk.tmLanguage
@@ -181,7 +181,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?!MsgBox)(?&lt;!\.)(?i:if|else|return|loop|break|for|while|class|extends|catch|finally|throw|try|until|continue|critical|exit|exitapp)\b</string>
+			<string>\b(?!MsgBox)(?&lt;!\.)(?i:if|else|switch|case|return|loop|break|for|while|class|extends|catch|finally|throw|try|until|continue|critical|exit|exitapp)\b</string>
 			<key>name</key>
 			<string>keyword.control.ahk</string>
 		</dict>


### PR DESCRIPTION
This PR adds highlighting for 2 keywords of [Swtich](https://www.autohotkey.com/docs/commands/Switch.htm) operator (`switch` & `case`)

```ahk
switch UserInput
{
case "btw":   Send, {backspace 4}by the way
case "otoh":  Send, {backspace 5}on the other hand
case "fl":    Send, {backspace 3}Florida
case "ca":    Send, {backspace 3}California
case "ahk":   Run, https://www.autohotkey.com
}
return
```