### PR TITLE
Remove eager extension activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"vscode": "^1.30.0"
 	},
 	"activationEvents": [
-		"*"
+		"onLanguage:ahk"
 	],
 	"main": "./out/extension",
 	"categories": [


### PR DESCRIPTION
It's a good practice to activate extension only when needed.

https://code.visualstudio.com/api/references/activation-events#Start-up

> The `"*"` activation event is emitted and interested extensions will be activated whenever VS Code starts up. To ensure a great end user experience, please use this activation event in your extension only when no other activation events combination works in your use-case.

> Note: An extension can listen to multiple activation events, and that is preferable to listening to `"*"`.